### PR TITLE
fix(admin): replace unsupported "password" field type with "string"

### DIFF
--- a/src/backend/server/admin.ts
+++ b/src/backend/server/admin.ts
@@ -2822,7 +2822,7 @@ const driverConfigs: Record<string, any> = {
       },
       {
         name: "password",
-        type: "password",
+        type: "string",
         default: "",
         required: true,
       },
@@ -3159,7 +3159,7 @@ const driverConfigs: Record<string, any> = {
       },
       {
         name: "password",
-        type: "password",
+        type: "string",
         default: "",
         required: false,
       },
@@ -3215,14 +3215,14 @@ const driverConfigs: Record<string, any> = {
       },
       {
         name: "password",
-        type: "password",
+        type: "string",
         default: "",
         required: true,
         help: "主密码（用于派生加密密钥）",
       },
       {
         name: "salt",
-        type: "password",
+        type: "string",
         default: "",
         required: false,
         help: "盐（第二密码）。可选但推荐，提高密钥强度",
@@ -3332,7 +3332,7 @@ const driverConfigs: Record<string, any> = {
       },
       { name: "meta_password", type: "string", default: "", required: false },
       { name: "username", type: "string", default: "", required: false },
-      { name: "password", type: "password", default: "", required: false },
+      { name: "password", type: "string", default: "", required: false },
       {
         name: "token",
         type: "string",
@@ -3528,7 +3528,7 @@ const driverConfigs: Record<string, any> = {
       { name: "operator_name", type: "string", default: "", required: true },
       {
         name: "operator_password",
-        type: "password",
+        type: "string",
         default: "",
         required: true,
       },


### PR DESCRIPTION
## Problem

On the manage → storages edit page, `Password` fields render as **"Unknown type"** and cannot be filled in (e.g. the `OpenList`/`AListV3` driver).

## Root cause

`driverConfigs` in `src/backend/server/admin.ts` declares `type: "password"` for 6 fields. The official frontend `Type` enum only supports `string / select / bool / text / number / float`, so any other value falls through to the `unknown_type` placeholder in `Item.tsx`.

The Go backend never emits a `password` type — untagged string fields default to `strings.ToLower(field.Type.Name())`, i.e. `string` (`internal/op/driver.go`).

## Fix

Change the 6 `type: "password"` declarations to `type: "string"`, matching what the Go backend emits for the same fields:

- 4× `password` (incl. AListV3 / OpenList driver)
- 1× `salt` (Crypt)
- 1× `operator_password`

No behavior is lost: the frontend already renders string inputs named `password` as masked password inputs (`Item.tsx`: `type={props.name == "password" ? "password" : "text"}`).

## Verification

- `tsc -p tsconfig.json --noEmit`: no new errors (`admin.ts`: 0)
- After the change the edit page shows a masked, editable Password input instead of the placeholder.