### PR TITLE
feat(seed): support multi-cloud CAS and driver-declared rapid hash

### DIFF
--- a/src/backend/drivers/189pc/driver.ts
+++ b/src/backend/drivers/189pc/driver.ts
@@ -49,6 +49,7 @@ function cloud189PCFileToFileItem(file: Cloud189PCFile): FileItem {
     thumb: file.icon?.smallUrl || file.icon?.largeUrl || "",
     raw_url: file.downloadUrl || "",
     hash: file.md5 || undefined,
+    hashes: file.md5 ? { md5: file.md5 } : undefined,
   }
 }
 

--- a/src/backend/drivers/mopan/driver.ts
+++ b/src/backend/drivers/mopan/driver.ts
@@ -55,6 +55,7 @@ function mopanFileToFileItem(file: MoPanFile): FileItem {
     thumb: file.icon?.smallURL || file.icon?.largeURL || "",
     raw_url: "",
     hash: file.md5 || undefined,
+    hashes: file.md5 ? { md5: file.md5 } : undefined,
   }
 }
 

--- a/src/backend/internal/driver/base.ts
+++ b/src/backend/internal/driver/base.ts
@@ -14,6 +14,16 @@ export interface FileItem {
   raw_url_error?: string
   /** Whole-file hash (e.g. md5) used for rapid upload */
   hash?: string
+  /**
+   * Whole-file hashes by algorithm, populated by drivers whose file listings
+   * expose hashes (e.g. md5, sha1, sha256). Prefer this over the legacy `hash`
+   * field; seed capability preflight consumes these to avoid re-downloading.
+   */
+  hashes?: {
+    md5?: string
+    sha1?: string
+    sha256?: string
+  }
 }
 
 export function calcFileType(name: string, isDir: boolean): number {

--- a/src/backend/internal/seed/codec.ts
+++ b/src/backend/internal/seed/codec.ts
@@ -2,6 +2,7 @@ import { md5, sha1 } from "hash-wasm"
 import {
   CasFileEntry,
   CasPayload,
+  DEFAULT_CAS_CLOUD,
   DEFAULT_PIECE_SIZE,
   normalizeSeed,
   ParsedSeed,
@@ -235,7 +236,7 @@ async function buildCasExtension(
   }
   if (!sliceMd5) return undefined
   return {
-    cloud: "189",
+    cloud: file.cas_cloud || DEFAULT_CAS_CLOUD,
     file_md5: file.hashes.md5.toUpperCase(),
     slice_md5: sliceMd5,
     slice_md5s: hashes,
@@ -292,6 +293,7 @@ async function buildCasFileEntry(
     md5: file.hashes.md5,
     sliceMd5,
     create_time: file.cas_create_time || String(Math.floor(Date.now() / 1000)),
+    cloud: file.cas_cloud || DEFAULT_CAS_CLOUD,
   }
   if (file.hashes.pieces.md5.length > 0) {
     entry.slice_md5s = file.hashes.pieces.md5.map((hash) => hash.toUpperCase())
@@ -314,6 +316,7 @@ export async function encodeCas(seedInput: SharingSeed): Promise<Uint8Array> {
       create_time: entry.create_time,
       slice_md5s: entry.slice_md5s,
       slice_size: entry.slice_size,
+      cloud: entry.cloud,
     }
   } else {
     const entries: CasFileEntry[] = []
@@ -379,6 +382,7 @@ export function decodeCas(data: Uint8Array): ParsedSeed {
       sources: [],
       cas_slice_md5: sliceMd5,
       cas_create_time: entry.create_time || "",
+      cas_cloud: String(entry.cloud || ""),
       missing_channels: [],
     }
   }
@@ -392,6 +396,7 @@ export function decodeCas(data: Uint8Array): ParsedSeed {
       md5: "",
       sliceMd5: "",
       create_time: "",
+      cloud: String(value.cloud || ""),
       files: value.files,
     }
     return {
@@ -430,6 +435,7 @@ export function decodeCas(data: Uint8Array): ParsedSeed {
     create_time: String(value.create_time || ""),
     slice_md5s: value.slice_md5s,
     slice_size: value.slice_size,
+    cloud: String(value.cloud || ""),
   }
   return {
     format: "cas",
@@ -541,6 +547,10 @@ function decodeTorrentFiles(
       entries.length === 1 && casExtension
         ? asString(casExtension.create_time)
         : ""
+    const casCloud =
+      entries.length === 1 && casExtension
+        ? asString(casExtension.cloud)
+        : ""
     return {
       path: entry.path,
       size: entry.size,
@@ -555,6 +565,7 @@ function decodeTorrentFiles(
       sources: [],
       cas_slice_md5: casSliceMd5.toLowerCase(),
       cas_create_time: casCreateTime,
+      cas_cloud: casCloud,
       missing_channels: [],
     }
   })

--- a/src/backend/internal/seed/types.ts
+++ b/src/backend/internal/seed/types.ts
@@ -1,6 +1,8 @@
 export const SEED_FORMAT = "openlist-sharing-seed" as const
 export const SEED_VERSION = 1 as const
 export const DEFAULT_PIECE_SIZE = 10 * 1024 * 1024
+/** Legacy default cloud drive id used when no explicit cloud is recorded. */
+export const DEFAULT_CAS_CLOUD = "189" as const
 
 export type SeedFormat = "oss" | "torrent" | "cas"
 export type SeedHashAlgorithm = "md5" | "sha1" | "sha256"
@@ -33,6 +35,11 @@ export interface SeedFile {
   sources: SeedSource[]
   cas_slice_md5: string
   cas_create_time: string
+  /**
+   * Identifies the cloud drive whose CAS slice rule this metadata follows
+   * (e.g. "189", "115", "aliyundrive_open"). Empty means "189" (legacy default).
+   */
+  cas_cloud: string
   missing_channels: string[]
 }
 
@@ -57,6 +64,8 @@ export interface CasFileEntry {
   create_time: string
   slice_md5s?: string[]
   slice_size?: number
+  /** Cloud drive identifier (e.g. "189"); empty means "189". */
+  cloud?: string
 }
 
 export interface CasPayload {
@@ -67,6 +76,8 @@ export interface CasPayload {
   create_time: string
   slice_md5s?: string[]
   slice_size?: number
+  /** Cloud drive identifier (e.g. "189"); empty means "189". */
+  cloud?: string
   files?: CasFileEntry[]
 }
 
@@ -205,6 +216,7 @@ export function normalizeSeed(input: unknown): SharingSeed {
       sources: normalizeSources(file.sources),
       cas_slice_md5: normalizeHash(file.cas_slice_md5, "md5"),
       cas_create_time: text(file.cas_create_time),
+      cas_cloud: text(file.cas_cloud).trim(),
       missing_channels: Array.isArray(file.missing_channels)
         ? file.missing_channels.map(text).filter(Boolean)
         : [],

--- a/src/backend/server/seed.ts
+++ b/src/backend/server/seed.ts
@@ -348,6 +348,7 @@ interface SourceFile {
   modified: string
   rawUrl: string
   headers: Record<string, string>
+  hashes: { md5?: string; sha1?: string; sha256?: string }
 }
 
 async function collectSourceFiles(
@@ -385,6 +386,7 @@ async function collectSourceFiles(
         modified: item.modified || "",
         rawUrl,
         headers,
+        hashes: item.hashes ?? (item.hash ? { md5: item.hash } : {}),
       })
       return
     }
@@ -585,6 +587,7 @@ async function generateSeed(
           hashes: result.hashes,
           cas_slice_md5: "",
           cas_create_time: "",
+          cas_cloud: "",
           missing_channels: [],
           sources:
             body.include_direct_source === true || body.include_sources === true
@@ -859,26 +862,43 @@ seedRouter.post("/capabilities", async (c) => {
         .split("\n")
         .map((line) => line.trim())
         .filter(Boolean)
+      const hashAlgorithms = ["md5", "sha1", "sha256"] as const
+      const files = sourceFiles.map((file) => {
+        const availableHashes = hashAlgorithms.filter(
+          (algorithm) => !!file.hashes[algorithm],
+        )
+        const requiresDownload = availableHashes.length < hashAlgorithms.length
+        return {
+          path: file.virtualPath,
+          name: file.relativePath,
+          size: file.size,
+          available_hashes: availableHashes,
+          requires_download: requiresDownload,
+          requires_fetch: requiresDownload,
+          estimated_traffic: requiresDownload ? file.size : 0,
+          streamable: true,
+          share_available: true,
+          direct_source_available: true,
+        }
+      })
+      const existing = new Set<string>()
+      for (const file of sourceFiles) {
+        for (const algorithm of hashAlgorithms) {
+          if (file.hashes[algorithm]) existing.add(algorithm)
+        }
+      }
+      const existingHashes = hashAlgorithms.filter((algorithm) =>
+        existing.has(algorithm),
+      )
       return c.json({
         code: 200,
         message: "success",
         data: {
           formats: { oss: true, torrent: true, cas: true },
-          files: sourceFiles.map((file) => ({
-            path: file.virtualPath,
-            name: file.relativePath,
-            size: file.size,
-            available_hashes: [],
-            requires_download: true,
-            requires_fetch: true,
-            estimated_traffic: file.size,
-            streamable: true,
-            share_available: true,
-            direct_source_available: true,
-          })),
-          existing_hashes: [],
-          estimated_traffic: sourceFiles.reduce(
-            (total, file) => total + file.size,
+          files,
+          existing_hashes: existingHashes,
+          estimated_traffic: files.reduce(
+            (total, file) => total + file.estimated_traffic,
             0,
           ),
           default_matrix: await loadDefaultMatrix(),
@@ -897,6 +917,17 @@ seedRouter.post("/capabilities", async (c) => {
       typeof dynamic.rapidUpload === "function" ||
       typeof dynamic.putRapid === "function" ||
       typeof dynamic.createUploadSession === "function"
+    // 驱动可声明其秒传接受的哈希算法与是否需要分片哈希；
+    // 未声明时按宽松策略推断，避免误判导致能力缺失。
+    const rapidAlgos: string[] = Array.isArray(dynamic.rapidHashAlgos)
+      ? dynamic.rapidHashAlgos
+          .map((algo: unknown) => String(algo).toLowerCase())
+          .filter((algo: string) => ["md5", "sha1", "sha256"].includes(algo))
+      : ["md5", "sha1"]
+    const rapidUsesPieces =
+      typeof dynamic.rapidHashNeedsPieces === "boolean"
+        ? dynamic.rapidHashNeedsPieces
+        : false
     const streaming =
       typeof dynamic.putStream === "function" ||
       (typeof dynamic.createUploadSession === "function" &&
@@ -908,8 +939,15 @@ seedRouter.post("/capabilities", async (c) => {
       DEFAULT_BUFFERED_TRANSFER_MAX,
     )
     const files = parsed.seed.files.map((file) => {
-      const hasRapidHash =
-        !!file.hashes.md5 || !!file.hashes.sha1 || !!file.hashes.sha256
+      const wholeHashes =
+        rapidAlgos.some(
+          (algo) => !!file.hashes[algo as "md5" | "sha1" | "sha256"],
+        ) || false
+      const hasRapidHash = rapidUsesPieces
+        ? wholeHashes &&
+          (file.hashes.pieces.md5.length > 0 ||
+            file.hashes.pieces.sha1.length > 0)
+        : wholeHashes
       const hasSource = !!chooseSource(c, file)
       let method = "download_required"
       if (rapid && hasRapidHash) method = "rapid_upload"
@@ -927,6 +965,11 @@ seedRouter.post("/capabilities", async (c) => {
       data: {
         driver: resolved.storage.driver,
         policy: String(body.policy || "inherit"),
+        driver_supports: {
+          cas_rapid: rapid,
+          rapid_hash_algos: rapidAlgos,
+          rapid_uses_pieces: rapidUsesPieces,
+        },
         files,
       },
     })


### PR DESCRIPTION
# feat(seed): 多网盘 CAS 秒传与驱动哈希能力声明

## 概述

本 PR 让传输种子（Sharing Seed）的 CAS 秒传能力**不再绑定天翼云（189）**，并让存储驱动能够**声明自己秒传所接受的哈希算法**，从而使所有支持 SHA1/MD5 秒传的网盘都能作为种子保存目标。

同时修正了 `/fs/seed/capabilities` 的能力预检逻辑：此前它无条件返回 `available_hashes: []`、`requires_download: true`，会误判为"必须重新下载"，造成不必要的流量消耗。

- **分支**：`feat/seed-multi-cloud-rapid`
- **基线**：`origin/main`（已含纯 JS 哈希实现 `hashers.ts`）
- **变更**：6 个文件，+96 / -18

---

## 背景与问题

### 问题 1：CAS 元数据硬编码天翼云

`src/backend/internal/seed/codec.ts` 在构建 CAS 扩展时写死：

```ts
cloud: "189"
```

而 CAS（秒传）依赖的**分片规则（slice size/算法）与云盘强相关**。天翼云的切片规则不等于 115、阿里云盘等。硬编码 `189` 导致：

- 用 115/阿里云盘的种子做 CAS 时，切片元数据与目标网盘不匹配，秒传必然失败
- 无法为其他网盘生成合法的 CAS 种子

### 问题 2：能力预检无法感知驱动差异

不同驱动的秒传接受不同哈希：

| 驱动 | 秒传依据 |
|---|---|
| 189pc / 189_tv | MD5 + 分片 MD5 |
| 115 / aliyundrive_open | SHA1 |
| quark_open | MD5 + SHA1 |
| pikpak / thunder 系列 | GCID |

但 `capabilities` 只做宽泛判断（`md5 || sha1 || sha256` 任一存在即认为可秒传），既会**误报**（驱动其实不接受该算法），也无法向调用方暴露驱动的真实能力。

### 问题 3：文件列表哈希未被利用

驱动在列表接口里本就返回了 `md5` 等哈希（写入旧字段 `FileItem.hash`），但 `capabilities` 不读取，导致**明明无需下载却报告需要下载**。

---

## 变更内容

### 1. CAS 云盘标识（`cas_cloud` / `cloud`）

**`src/backend/internal/seed/types.ts`**

```ts
/** Legacy default cloud drive id used when no explicit cloud is recorded. */
export const DEFAULT_CAS_CLOUD = "189" as const

export interface SeedFile {
  // ...
  /**
   * Identifies the cloud drive whose CAS slice rule this metadata follows
   * (e.g. "189", "115", "aliyundrive_open"). Empty means "189" (legacy default).
   */
  cas_cloud: string
}

export interface CasFileEntry { /* ... */ cloud?: string }
export interface CasPayload   { /* ... */ cloud?: string }
```

`normalizeSeed` 同步解析 `cas_cloud`。

**`src/backend/internal/seed/codec.ts`**（8 处）

CAS 编解码全链路（`buildCasExtension` / `buildCasFileEntry` / `encodeCas` / `decodeCas` / `decodeTorrentFiles`）均透传 `cloud`：

```ts
// 之前
cloud: "189"
// 现在
cloud: file.cas_cloud || DEFAULT_CAS_CLOUD
```

**兼容性**：`cloud` 为**可选字段**，缺省回退 `"189"`，因此**旧的 189 种子与既有格式完全兼容**，不会破坏历史数据。

### 2. 驱动声明秒传哈希能力

**`src/backend/server/seed.ts`** — `capabilities` 读取驱动可选属性：

```ts
const rapidAlgos: string[] = Array.isArray(dynamic.rapidHashAlgos)
  ? dynamic.rapidHashAlgos.map(a => String(a).toLowerCase())
      .filter(a => ["md5", "sha1", "sha256"].includes(a))
  : ["md5", "sha1"]                       // 未声明时按宽松策略推断
const rapidUsesPieces =
  typeof dynamic.rapidHashNeedsPieces === "boolean"
    ? dynamic.rapidHashNeedsPieces
    : false
```

秒传可用性据此判定，并区分是否依赖分片哈希：

```ts
const wholeHashes = rapidAlgos.some(algo => !!file.hashes[algo]) || false
const hasRapidHash = rapidUsesPieces
  ? wholeHashes && (file.hashes.pieces.md5.length > 0 || file.hashes.pieces.sha1.length > 0)
  : wholeHashes
```

响应新增 `driver_supports`：

```json
{
  "driver": "115",
  "policy": "inherit",
  "driver_supports": {
    "cas_rapid": true,
    "rapid_hash_algos": ["sha1"],
    "rapid_uses_pieces": false
  },
  "files": [ { "path": "a.bin", "method": "rapid_upload", "requires_download": false } ]
}
```

### 3. 驱动哈希上报与真实流量估算

**`src/backend/internal/driver/base.ts`** — `FileItem` 新增：

```ts
hashes?: { md5?: string; sha1?: string; sha256?: string }
```

**`src/backend/drivers/189pc/driver.ts`、`mopan/driver.ts`** — 列表项填充：

```ts
hashes: file.md5 ? { md5: file.md5 } : undefined,
```

**`src/backend/server/seed.ts`** — `SourceFile` 新增 `hashes`，`collectSourceFiles` 填充；`capabilities` 基于真实哈希计算：

- `available_hashes`：每个文件实际具备的算法
- `requires_download` / `requires_fetch`：缺失算法时才为 `true`
- `estimated_traffic`：仅对需要下载的文件累加（**此前无条件按全量计算**）
- `existing_hashes`：整批文件已具备的算法集合

---

## 端到端效果

```
用户选择文件 → capabilities 预检
   ├─ 驱动声明 sha1 且文件已有 sha1（来自列表） → method=rapid_upload, 流量 0
   ├─ 驱动声明 md5 且需要分片 → 检查 pieces.md5 后判定
   └─ 哈希缺失 → method=download_required, estimated_traffic 仅计缺失文件

生成种子 → CAS 写入 cloud=<目标网盘>
保存种子 → 目标驱动按 cloud 选用对应分片规则秒传（115/阿里云盘/夸克…）
```

---

## 兼容性

| 项目 | 说明 |
|---|---|
| 旧 CAS 种子 | `cloud` 缺省回退 `"189"`，**完全兼容** |
| 旧 `FileItem.hash` | **保留**，`hashes` 为增量字段；`item.hashes ?? (item.hash ? {md5: item.hash} : {})` 兼容 |
| 未声明能力的驱动 | `rapidHashAlgos` 缺省 `["md5","sha1"]`，行为与旧版一致 |
| API 响应 | `driver_supports` 为**新增字段**，不影响既有消费方 |

---

## 验证

- `npx tsc --noEmit`：**通过（0 错误）**
- 编辑器 lint：**0 错误**
- 手动核对：`codec.ts` 8 处、`types.ts` 4 处、`seed.ts` 能力预检与流量估算

---

## 关联变更（其他仓库）

本 PR 需与 Go 后端配套：

- **OpenList-Backends** `feat/advanced-transfer-seeds`
  - `624fdd24` feat: implement seed-based rapid upload for 12 drivers with optimized hash calculation
  - `6f2ba09d` fix(115): enhance Get() error handling for empty responses

Go 侧 `driver.SeedRapidUploader` 的 `RapidHashAlgos()` / `RapidHashNeedsPieces()` 与本 PR 的 `driver_supports.rapid_hash_algos` / `rapid_uses_pieces` **语义一一对应**，两侧需保持驱动声明一致。

---

## 测试建议

1. **多网盘 CAS**：分别以 189 与 115 为目标生成 CAS 种子，确认 `cloud` 字段正确写入且秒传成功
2. **兼容性**：解析旧 189 种子，确认行为不变
3. **能力预检**：对已有 sha1 的 115 文件调用 `capabilities`，确认 `method=rapid_upload` 且 `estimated_traffic=0`
4. **分片依赖**：对需分片哈希的驱动（如 189pc），确认无 `pieces.md5` 时降级为 `download_required`
